### PR TITLE
fix: invalid username or repos, timeout error #22

### DIFF
--- a/util.js
+++ b/util.js
@@ -91,24 +91,27 @@ async function writeDocsWithConfig(user, repo, readmeData, config) {
 async function getReadme(user, repo) {
   mainConfig.user = user;
   mainConfig.repo = repo;
+  try {
+    const readme = await axios.get(
+      `https://api.github.com/repos/${user}/${repo}/readme`
+    );
+    const readmeUrl = readme.data.download_url;
+    const readmeData = await axios.get(readmeUrl);
 
-  const readme = await axios.get(
-    `https://api.github.com/repos/${user}/${repo}/readme`
-  );
-  const readmeUrl = readme.data.download_url;
-  const readmeData = await axios.get(readmeUrl);
+    if (!fs.existsSync("./_docs/")) {
+      fs.mkdirSync("./_docs/");
+    }
 
-  if (!fs.existsSync("./_docs/")) {
-    fs.mkdirSync("./_docs/");
-  }
+    if (!fs.existsSync(`./_docs/${user}-${repo}/`)) {
+      fs.mkdirSync(`./_docs/${user}-${repo}/`);
+    }
 
-  if (!fs.existsSync(`./_docs/${user}-${repo}/`)) {
-    fs.mkdirSync(`./_docs/${user}-${repo}/`);
-  }
-
-  // Write file only if github readme is different from local copy
-  if (isDiffReadme(user, repo, readmeData.data)) {
-    await writeDocs(user, repo, readmeData.data);
+    // Write file only if github readme is different from local copy
+    if (isDiffReadme(user, repo, readmeData.data)) {
+      await writeDocs(user, repo, readmeData.data);
+    }
+  } catch (error) {
+    return;
   }
 }
 


### PR DESCRIPTION
Fixes #22 I put the `axios` request in the `try catch` block, so if the username or repos name is invalid, it will simply go catch block then finish the `getReadme()` function. So far, when users put wrong names, it will just normal 'cannot get message'. 

I don't know how to specifically do i need to change for this (either simply redirect to the home page or make a 404 page), so please let me know if there is anything I can help more!!